### PR TITLE
Fix types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-tweakpane",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Solid components for Tweakpane library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
@@ -11,7 +11,8 @@
       "require": "./dist/cjs/index.js"
     },
     "import": "./dist/es/index.js",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "./dist"


### PR DESCRIPTION
Thanks for this package! I had a problem with the types when using it and I hope this will help.

```
Could not find a declaration file for module 'solid-tweakpane'. '/node_modules/solid-tweakpane/dist/es/index.js' implicitly has an 'any' type.
  There are types at '/node_modules/solid-tweakpane/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports".
  The 'solid-tweakpane' library may need to update its package.json or typings
```

